### PR TITLE
Blackboard indexer-based setter and getter

### DIFF
--- a/Examples/Scripts/NPBehaveExampleEnemyAI.cs
+++ b/Examples/Scripts/NPBehaveExampleEnemyAI.cs
@@ -47,7 +47,7 @@ public class NPBehaveExampleEnemyAI : MonoBehaviour
                             {
                                 if (!_shouldCancel)
                                 {
-                                    MoveTowards(blackboard.GetVector3("playerLocalPos"));
+                                    MoveTowards(blackboard.Get<Vector3>("playerLocalPos"));
                                     return Action.Result.PROGRESS;
                                 }
                                 else

--- a/Examples/Scripts/NPBehaveExampleEnemyAI.cs
+++ b/Examples/Scripts/NPBehaveExampleEnemyAI.cs
@@ -71,8 +71,8 @@ public class NPBehaveExampleEnemyAI : MonoBehaviour
     private void UpdatePlayerDistance()
     {
         Vector3 playerLocalPos = this.transform.InverseTransformPoint(GameObject.FindGameObjectWithTag("Player").transform.position);
-        behaviorTree.Blackboard.Set("playerLocalPos", playerLocalPos);
-        behaviorTree.Blackboard.Set("playerDistance", playerLocalPos.magnitude);
+        behaviorTree.Blackboard["playerLocalPos"] = playerLocalPos;
+        behaviorTree.Blackboard["playerDistance"] = playerLocalPos.magnitude;
     }
 
     private void MoveTowards(Vector3 localPosition)

--- a/Examples/Scripts/NPBehaveExampleHelloBlackboardsAI.cs
+++ b/Examples/Scripts/NPBehaveExampleHelloBlackboardsAI.cs
@@ -10,7 +10,7 @@ public class NPBehaveExampleHelloBlackboardsAI : MonoBehaviour
         behaviorTree = new Root(
 
             // toggle the 'toggled' blackboard boolean flag around every 500 milliseconds
-            new Service(0.5f, () => { behaviorTree.Blackboard["foo"] = !behaviorTree.Blackboard.GetBool("foo"); },
+            new Service(0.5f, () => { behaviorTree.Blackboard["foo"] = !behaviorTree.Blackboard.Get<bool>("foo"); },
 
                 new Selector(
 

--- a/Examples/Scripts/NPBehaveExampleHelloBlackboardsAI.cs
+++ b/Examples/Scripts/NPBehaveExampleHelloBlackboardsAI.cs
@@ -10,7 +10,7 @@ public class NPBehaveExampleHelloBlackboardsAI : MonoBehaviour
         behaviorTree = new Root(
 
             // toggle the 'toggled' blackboard boolean flag around every 500 milliseconds
-            new Service(0.5f, () => { behaviorTree.Blackboard.Set("foo", !behaviorTree.Blackboard.GetBool("foo")); },
+            new Service(0.5f, () => { behaviorTree.Blackboard["foo"] = !behaviorTree.Blackboard.GetBool("foo"); },
 
                 new Selector(
 

--- a/Examples/Scripts/NPBehaveExampleSwarmEnemyAI.cs
+++ b/Examples/Scripts/NPBehaveExampleSwarmEnemyAI.cs
@@ -95,27 +95,27 @@ public class NPBehaveExampleSwarmEnemyAI : MonoBehaviour
         Vector3 playerLocalPos = this.transform.InverseTransformPoint(GameObject.FindGameObjectWithTag("Player").transform.position);
 
         // update all our distances
-        ownBlackboard.Set("playerLocalPos", playerLocalPos);
-        ownBlackboard.Set("playerInRange", playerLocalPos.magnitude < 7.5f);
+        ownBlackboard["playerLocalPos"]= playerLocalPos;
+        ownBlackboard["playerInRange"]= playerLocalPos.magnitude < 7.5f;
 
         // if we are not yet engaging the player, but he is in range and there are not yet other 2 guys engaged with him
         if (ownBlackboard.GetBool("playerInRange") && !ownBlackboard.GetBool("engaged") && sharedBlackboard.GetInt("numEngagedActors") < 2)
         {
             // increment the shared 'numEngagedActors'
-            sharedBlackboard.Set("numEngagedActors", sharedBlackboard.GetInt("numEngagedActors") + 1);
+            sharedBlackboard["numEngagedActors"]= sharedBlackboard.GetInt("numEngagedActors") + 1;
 
             // set this instance to 'engaged'
-            ownBlackboard.Set("engaged", true);
+            ownBlackboard["engaged"]= true;
         }
 
         // if we were engaging the player, but he is not in the range anymore
         if (!ownBlackboard.GetBool("playerInRange") && ownBlackboard.GetBool("engaged"))
         {
             // decrement the shared 'numEngagedActors'
-            sharedBlackboard.Set("numEngagedActors", sharedBlackboard.GetInt("numEngagedActors") - 1);
+            sharedBlackboard["numEngagedActors"]= sharedBlackboard.GetInt("numEngagedActors") - 1;
 
             // set this instance to 'engaged'
-            ownBlackboard.Set("engaged", false);
+            ownBlackboard["engaged"]= false;
         }
     }
 

--- a/Examples/Scripts/NPBehaveExampleSwarmEnemyAI.cs
+++ b/Examples/Scripts/NPBehaveExampleSwarmEnemyAI.cs
@@ -54,7 +54,7 @@ public class NPBehaveExampleSwarmEnemyAI : MonoBehaviour
                             {
                                 if (!_shouldCancel)
                                 {
-                                    MoveTowards(ownBlackboard.GetVector3("playerLocalPos"));
+                                    MoveTowards(ownBlackboard.Get<Vector3>("playerLocalPos"));
                                     return Action.Result.PROGRESS;
                                 }
                                 else
@@ -99,20 +99,20 @@ public class NPBehaveExampleSwarmEnemyAI : MonoBehaviour
         ownBlackboard["playerInRange"]= playerLocalPos.magnitude < 7.5f;
 
         // if we are not yet engaging the player, but he is in range and there are not yet other 2 guys engaged with him
-        if (ownBlackboard.GetBool("playerInRange") && !ownBlackboard.GetBool("engaged") && sharedBlackboard.GetInt("numEngagedActors") < 2)
+        if (ownBlackboard.Get<bool>("playerInRange") && !ownBlackboard.Get<bool>("engaged") && sharedBlackboard.Get<int>("numEngagedActors") < 2)
         {
             // increment the shared 'numEngagedActors'
-            sharedBlackboard["numEngagedActors"]= sharedBlackboard.GetInt("numEngagedActors") + 1;
+            sharedBlackboard["numEngagedActors"]= sharedBlackboard.Get<int>("numEngagedActors") + 1;
 
             // set this instance to 'engaged'
             ownBlackboard["engaged"]= true;
         }
 
         // if we were engaging the player, but he is not in the range anymore
-        if (!ownBlackboard.GetBool("playerInRange") && ownBlackboard.GetBool("engaged"))
+        if (!ownBlackboard.Get<bool>("playerInRange") && ownBlackboard.Get<bool>("engaged"))
         {
             // decrement the shared 'numEngagedActors'
-            sharedBlackboard["numEngagedActors"]= sharedBlackboard.GetInt("numEngagedActors") - 1;
+            sharedBlackboard["numEngagedActors"]= sharedBlackboard.Get<int>("numEngagedActors") - 1;
 
             // set this instance to 'engaged'
             ownBlackboard["engaged"]= false;

--- a/Scripts/Blackboard.cs
+++ b/Scripts/Blackboard.cs
@@ -62,6 +62,15 @@ namespace NPBehave
             }
         }
 
+        public object this[string key] {
+            get {
+                return Get(key);
+            }
+            set {
+                Set(key, value);
+            }
+        }
+
         public void Set(string key)
         {
             if (!Isset(key))

--- a/Scripts/Blackboard.cs
+++ b/Scripts/Blackboard.cs
@@ -115,41 +115,14 @@ namespace NPBehave
             }
         }
 
-        public bool GetBool(string key)
+        public T Get<T>(string key)
         {
             object result = Get(key);
             if (result == null)
             {
-                return false;
+                return default(T);
             }
-            return (bool)result;
-        }
-        public float GetFloat(string key)
-        {
-            object result = Get(key);
-            if (result == null)
-            {
-                return float.NaN;
-            }
-            return (float)Get(key);
-        }
-        public Vector3 GetVector3(string key)
-        {
-            object result = Get(key);
-            if (result == null)
-            {
-                return Vector3.zero;
-            }
-            return (Vector3)Get(key);
-        }
-        public int GetInt(string key)
-        {
-            object result = Get(key);
-            if (result == null)
-            {
-                return 0;
-            }
-            return (int)Get(key);
+            return (T)result;
         }
 
         public object Get(string key)


### PR DESCRIPTION
Why have `blackboard.Set("test", true)` when you can `blackboard["test"] = true`
same goes for `blackboard.GetBool("test")` which is now `blackboard.Get<bool>("test")`. The later allows you to get any type of value, and if the value is not found it returns `default(bool)` instead of the current hardcoded default value.

P.S. you can also do `(bool)blackboard["test"]`, but that's for crazy people.
