### PR TITLE
Exception tests fixed for 5.6 (NUnit3)

### DIFF
--- a/Editor/Tests/Composite/ParallelTest.cs
+++ b/Editor/Tests/Composite/ParallelTest.cs
@@ -275,7 +275,6 @@ namespace NPBehave
         }
 
         [Test]
-        [ExpectedException(typeof(Exception))]
         public void StopLowerPriorityChildrenForChild_WithoutImmediateRestart_ShouldThrowError()
         {
             Parallel.Policy failurePolicy = Parallel.Policy.ALL;
@@ -286,10 +285,11 @@ namespace NPBehave
             Parallel sut = new Parallel(successPolicy, failurePolicy, firstChild, secondChild);
             TestRoot behaviorTree = CreateBehaviorTree(sut);
 
-            behaviorTree.Start();
-            firstChild.Finish(false);
-            sut.StopLowerPriorityChildrenForChild(firstChild, false);
-
+            Assert.That(() => {
+                behaviorTree.Start();
+                firstChild.Finish(false);
+                sut.StopLowerPriorityChildrenForChild(firstChild, false);
+            }, Throws.TypeOf<Exception>());
         }
     }
 }

--- a/Scripts/Task/NavMoveTo.cs
+++ b/Scripts/Task/NavMoveTo.cs
@@ -10,7 +10,7 @@ namespace NPBehave
 #if UNITY_5_5
         private UnityEngine.AI.NavMeshAgent agent;
 #else
-        private NavMeshAgent agent;
+        private UnityEngine.AI.NavMeshAgent agent;
 #endif
         private string blackboardKey;
         private float tolerance;
@@ -33,7 +33,7 @@ namespace NPBehave
 #if UNITY_5_5
         public NavMoveTo(UnityEngine.AI.NavMeshAgent agent, string blackboardKey, float tolerance = 1.0f, bool stopOnTolerance = false, float updateFrequency = 0.1f, float updateVariance = 0.025f) : base("NavMoveTo")
 #else
-        public NavMoveTo(NavMeshAgent agent, string blackboardKey, float tolerance = 1.0f, bool stopOnTolerance = false, float updateFrequency = 0.1f, float updateVariance = 0.025f) : base("NavMoveTo")
+        public NavMoveTo(UnityEngine.AI.NavMeshAgent agent, string blackboardKey, float tolerance = 1.0f, bool stopOnTolerance = false, float updateFrequency = 0.1f, float updateVariance = 0.025f) : base("NavMoveTo")
 #endif
         {
             this.agent = agent;


### PR DESCRIPTION
In NUnit 3.0 (Unity5.6+) using ExpectedExceptionAttribute throws an error, since it has been removed.
This fix resolves it.