### PR TITLE
Added Randomized Selector and Sequence

### DIFF
--- a/Scripts/Composite/RandomSelector.cs
+++ b/Scripts/Composite/RandomSelector.cs
@@ -1,0 +1,100 @@
+﻿using UnityEngine;
+using UnityEngine.Assertions;
+using System.Collections;
+
+
+
+namespace NPBehave
+{
+    public class RandomSelector : Composite
+    {
+        static System.Random rng = new System.Random();
+
+        private int currentIndex = -1;
+        private int[] randomizedOrder;
+
+        public RandomSelector(params Node[] children) : base("Radom Selector", children)
+        {
+            randomizedOrder = new int[children.Length];
+            for (int i = 0; i < Children.Length; i++) {
+                randomizedOrder[i] = i;
+            }
+        }
+
+
+        protected override void DoStart()
+        {
+            foreach (Node child in Children) {
+                Assert.AreEqual(child.CurrentState, State.INACTIVE);
+            }
+
+            currentIndex = -1;
+
+            // Shuffling
+            int n = randomizedOrder.Length;
+            while (n > 1) {
+                int k = rng.Next(n--);
+                int temp = randomizedOrder[n];
+                randomizedOrder[n] = randomizedOrder[k];
+                randomizedOrder[k] = temp;
+            }
+
+            ProcessChildren();
+        }
+
+
+
+        protected override void DoStop()
+        {
+            Children[currentIndex].Stop();
+        }
+
+        protected override void DoChildStopped(Node child, bool result)
+        {
+            if (result) {
+                Stopped(true);
+            } else {
+                ProcessChildren();
+            }
+        }
+
+        private void ProcessChildren()
+        {
+            if (++currentIndex < Children.Length) {
+                if (IsStopRequested) {
+                    Stopped(false);
+                } else {
+                    Children[randomizedOrder[currentIndex]].Start();
+                }
+            } else {
+                Stopped(false);
+            }
+        }
+
+        public override void StopLowerPriorityChildrenForChild(Node abortForChild, bool immediateRestart)
+        {
+            int indexForChild = 0;
+            bool found = false;
+            foreach (Node currentChild in Children) {
+                if (currentChild == abortForChild) {
+                    found = true;
+                } else if (!found) {
+                    indexForChild++;
+                } else if (found && currentChild.IsActive) {
+                    if (immediateRestart) {
+                        currentIndex = indexForChild - 1;
+                    } else {
+                        currentIndex = Children.Length;
+                    }
+                    currentChild.Stop();
+                    break;
+                }
+            }
+        }
+
+        override public string ToString()
+        {
+            return base.ToString() + "[" + this.currentIndex + "]";
+        }
+    }
+}

--- a/Scripts/Composite/RandomSequence.cs
+++ b/Scripts/Composite/RandomSequence.cs
@@ -1,0 +1,96 @@
+﻿using UnityEngine;
+using UnityEngine.Assertions;
+using System.Collections;
+
+namespace NPBehave
+{
+    public class RandomSequence : Composite
+    {
+        static System.Random rng = new System.Random();
+
+        private int currentIndex = -1;
+        private int[] randomizedOrder;
+
+        public RandomSequence(params Node[] children) : base("Random Sequence", children)
+        {
+            randomizedOrder = new int[children.Length];
+            for (int i = 0; i < Children.Length; i++) {
+                randomizedOrder[i] = i;
+            }
+        }
+
+        protected override void DoStart()
+        {
+            foreach (Node child in Children) {
+                Assert.AreEqual(child.CurrentState, State.INACTIVE);
+            }
+
+            currentIndex = -1;
+
+            // Shuffling
+            int n = randomizedOrder.Length;
+            while (n > 1) {
+                int k = rng.Next(n--);
+                int temp = randomizedOrder[n];
+                randomizedOrder[n] = randomizedOrder[k];
+                randomizedOrder[k] = temp;
+            }
+
+            ProcessChildren();
+        }
+
+        protected override void DoStop()
+        {
+            Children[currentIndex].Stop();
+        }
+
+
+        protected override void DoChildStopped(Node child, bool result)
+        {
+            if (result) {
+                ProcessChildren();
+            } else {
+                Stopped(false);
+            }
+        }
+
+        private void ProcessChildren()
+        {
+            if (++currentIndex < Children.Length) {
+                if (IsStopRequested) {
+                    Stopped(false);
+                } else {
+                    Children[randomizedOrder[currentIndex]].Start();
+                }
+            } else {
+                Stopped(true);
+            }
+        }
+
+        public override void StopLowerPriorityChildrenForChild(Node abortForChild, bool immediateRestart)
+        {
+            int indexForChild = 0;
+            bool found = false;
+            foreach (Node currentChild in Children) {
+                if (currentChild == abortForChild) {
+                    found = true;
+                } else if (!found) {
+                    indexForChild++;
+                } else if (found && currentChild.IsActive) {
+                    if (immediateRestart) {
+                        currentIndex = indexForChild - 1;
+                    } else {
+                        currentIndex = Children.Length;
+                    }
+                    currentChild.Stop();
+                    break;
+                }
+            }
+        }
+
+        override public string ToString()
+        {
+            return base.ToString() + "[" + this.currentIndex + "]";
+        }
+    }
+}


### PR DESCRIPTION
Added Randomized Selector and Randomized Sequence.
**Randomized Sequence** runs children in random order until one until one fails and fail (succeeds if non of the children fails).
**Randomized Selector** runs children in random order until one succeeds and succeed (succeeds if one of the children succeeds).

Selector is not biased and picks totally random order 
![RandomDistributionBetter](https://user-images.githubusercontent.com/38141841/59422993-8e80d580-8dd1-11e9-9c94-4bc6e8ab96aa.png)

While the previous method of using `Random` decorator on each child chooses 1st option more often
![RandomDistribution](https://user-images.githubusercontent.com/38141841/59423063-b112ee80-8dd1-11e9-9c04-fd7694ecd88b.png)

